### PR TITLE
Use if let syntax for Dictionary {group, count}by

### DIFF
--- a/ExSwift/Array.swift
+++ b/ExSwift/Array.swift
@@ -389,7 +389,7 @@ extension Array {
     */
     func groupBy <U> (groupingFunction group: (Element) -> U) -> Dictionary<U, Array> {
 
-        var result = Dictionary<U, Element[]>();
+        var result = Dictionary<U, Element[]>()
         
         for item in self {
             
@@ -400,7 +400,6 @@ extension Array {
                 result[groupKey] = elem + [item]
             } else {
                 result[groupKey] = [item]
-                
             }
         }
         
@@ -414,7 +413,7 @@ extension Array {
     */
     func countBy <U> (groupingFunction group: (Element) -> U) -> Dictionary<U, Int> {
         
-        var result = Dictionary<U, Int>();
+        var result = Dictionary<U, Int>()
         
         for item in self {
             let groupKey = group(item)

--- a/ExSwift/Dictionary.swift
+++ b/ExSwift/Dictionary.swift
@@ -197,26 +197,23 @@ extension Dictionary {
     *  @param groupingFunction
     *  @return Grouped dictionary
     */
-    func groupBy <T> (groupingFunction group: (KeyType, ValueType) -> (T)) -> Dictionary<T, Array<ValueType>> {
+    func groupBy <T> (groupingFunction group: (KeyType, ValueType) -> T) -> Dictionary<T, Array<ValueType>> {
         
-        var result = Dictionary<T, ValueType[]>();
+        var result = Dictionary<T, ValueType[]>()
         
         for (key, value) in self {
             
             let groupKey = group(key, value)
-            var array: ValueType[]? = nil
             
-            //  This is the first object for groupKey
-            if !result.has(groupKey) {
-                result[groupKey] = [value]
+            // If element has already been added to dictionary, append to it. If not, create one.
+            if let elem = result[groupKey] {
+                result[groupKey] = elem + [value]
             } else {
-                result[groupKey] = result[groupKey]! + [value]
+                result[groupKey] = [value]
             }
-            
         }
         
         return result
-        
     }
     
     /**
@@ -226,23 +223,21 @@ extension Dictionary {
     */
     func countBy <T> (groupingFunction group: (KeyType, ValueType) -> (T)) -> Dictionary<T, Int> {
         
-        var result = Dictionary<T, Int>();
+        var result = Dictionary<T, Int>()
         
         for (key, value) in self {
             
             let groupKey = group(key, value)
-
-            //  This is the first object for groupKey
-            if !result.has(groupKey) {
-                result[groupKey] = 1
-            } else {
-                result[groupKey] = result[groupKey]! + 1
-            }
             
+            // If element has already been added to dictionary, append to it. If not, create one.
+            if let elem = result[groupKey] {
+                result[groupKey] = elem + 1
+            } else {
+                result[groupKey] = 1
+            }
         }
         
         return result
-        
     }
     
     /**


### PR DESCRIPTION
Didn't realize Dictionary had the same methods to clean up! Almost amended my pull request before it got through, here you go!

This uses the same idiomatic if let syntax for the Dictionary
versions of groupBy and countBy, as well as removing a few
unnecessary semi-colons.
