### PR TITLE
Added a sortBy method

### DIFF
--- a/ExSwift/Array.swift
+++ b/ExSwift/Array.swift
@@ -664,6 +664,19 @@ extension Array {
         return result
         
     }
+  
+    /**
+    *  Sorts the array by the given comparison function
+    *  @param isOrderedBefore
+    *  @return An array that is sorted by the given function
+    */
+    func sortBy (isOrderedBefore: (T, T) -> Bool) -> Array<T> {
+        var clone = self
+        clone.unshare()
+        clone.sort(isOrderedBefore)
+        return clone
+    }
+
 
     /**
     *  Removes the last element from self and returns it

--- a/ExSwiftTests/ExSwiftArrayTests.swift
+++ b/ExSwiftTests/ExSwiftArrayTests.swift
@@ -17,6 +17,16 @@ class ExtensionsArrayTests: XCTestCase {
         array = [1, 2, 3, 4, 5]
     }
 
+    func testSortBy () {
+        var sourceArray = [2,3,6,5]
+        var sortedArray = sourceArray.sortBy {$0 < $1}
+        
+        // check that the source array as not been mutated
+        XCTAssertEqualObjects(sourceArray, [2, 3, 6, 5])
+        // check that the destination has been sorted
+        XCTAssertEqualObjects(sortedArray, [2, 3, 5, 6])
+    }
+  
     func testReject () {
         var odd = array.reject({
             return $0 % 2 == 0

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Name | Signature
 **`reduceRight`**|`reduceRight <U>(initial: U, combine: (U, Element) -> U) -> U`
 **`implode`**|`implode <C: ExtensibleCollection> (separator: C) -> C?`
 **`flatten`**|`flatten <OutType> () -> OutType[]`
+**`sortBy`**|`sortBy (isOrderedBefore: (T, T) -> Bool) -> Array<T> `
 
 #### Class Methods ####
 


### PR DESCRIPTION
This is a great set of utility methods. Nice work. 

This PR is for a very small addition, `sortBy`. I really dislike the way that the Swift `Array.sort` mutates the array itself. This `sortBy` implementation copies and sorts and as a result supports a more fluent usage:

```
array.sort({$0 > $1}).unique()
```
