### PR TITLE
Added mapi method

### DIFF
--- a/ExSwift/Array.swift
+++ b/ExSwift/Array.swift
@@ -732,7 +732,21 @@ internal extension Array {
         return mapped
         
     }
-    
+
+    /**
+        Same as map, but with an extra index argument.
+
+        :param: mapFunction
+        :returns: Mapped array
+    */
+    func mapi <U> (transform: (Int, T) -> U) -> [U] {
+        var result = [U]()
+        for (i, e) in enumerate(self) {
+            result.append(transform(i, e))
+        }
+        return result
+    }
+
     /**
         self.reduce with initial value self.first()
     */

--- a/ExSwiftTests/ExSwiftArrayTests.swift
+++ b/ExSwiftTests/ExSwiftArrayTests.swift
@@ -390,6 +390,11 @@ class ExtensionsArrayTests: XCTestCase {
         
         XCTAssertEqual(m, [2, 3, 4])
     }
+
+    func testMapi() {
+        let m = array.mapi({ $0 + 1 })
+        XCTAssertEqual(m, [2, 3, 4, 5])
+    }
     
     func testSubscriptConflicts() {
         let array1 = ["zero", "one", "two", "three"][rangeAsArray: 1...3]


### PR DESCRIPTION
Same as built-in method `map`, but with an extra index argument.
I don't know if the name `mapi` is a standard, I just used the same name as in [OCaml](http://caml.inria.fr/pub/docs/manual-ocaml/libref/List.html#VALmapi).