### PR TITLE
Update Dictionary.swift

### DIFF
--- a/ExSwift/Dictionary.swift
+++ b/ExSwift/Dictionary.swift
@@ -397,6 +397,6 @@ public func & <K, V: Equatable> (first: [K: V], second: [K: V]) -> [K: V] {
 /**
     Union operator
 */
-public func | <K, V: Equatable> (first: [K: V], second: [K: V]) -> [K: V] {
+public func | <K: Hashable, V> (first: [K: V], second: [K: V]) -> [K: V] {
     return first.union(second)
 }


### PR DESCRIPTION
Using PIPE (Union operator) on dictionaries of the type [String:AnyObject] fails because AnyObject doesn't conform to Equatable.
Change the type constraint of the generic declaration to match Swift's Dictionary generic type.
Now it'll work on any dictionary :]

Didn't test other operators but this one. Chances are they can also be modified in the same way.
