### PR TITLE
Added overloaded ltrimmed and rtrimmed methods

### DIFF
--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -137,7 +137,16 @@ public extension String {
         :returns: Stripped string
     */
     func ltrimmed () -> String {
-        if let range = rangeOfCharacterFromSet(NSCharacterSet.whitespaceAndNewlineCharacterSet().invertedSet) {
+        return ltrimmed(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+    }
+    
+    /**
+        Strips the specified characters from the beginning of self.
+    
+        :returns: Stripped string
+    */
+    func ltrimmed (set: NSCharacterSet) -> String {
+        if let range = rangeOfCharacterFromSet(set.invertedSet) {
             return self[range.startIndex..<endIndex]
         }
         
@@ -150,7 +159,16 @@ public extension String {
         :returns: Stripped string
     */
     func rtrimmed () -> String {
-        if let range = rangeOfCharacterFromSet(NSCharacterSet.whitespaceAndNewlineCharacterSet().invertedSet, options: NSStringCompareOptions.BackwardsSearch) {
+        return rtrimmed(NSCharacterSet.whitespaceAndNewlineCharacterSet())
+    }
+    
+    /**
+        Strips the specified characters from the end of self.
+    
+        :returns: Stripped string
+    */
+    func rtrimmed (set: NSCharacterSet) -> String {
+        if let range = rangeOfCharacterFromSet(set.invertedSet, options: NSStringCompareOptions.BackwardsSearch) {
             return self[startIndex..<range.endIndex]
         }
         

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -130,4 +130,14 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertEqual("AB ".rtrimmed(), "AB")
         XCTAssertEqual("\n ABC   ".rtrimmed(), "\n ABC")
     }
+    
+    func testLTrimmedForSet () {
+        XCTAssertEqual("ab   ".ltrimmed(NSCharacterSet.alphanumericCharacterSet()), "   ")
+        XCTAssertEqual("  ab".ltrimmed(NSCharacterSet.alphanumericCharacterSet()), "  ab")
+    }
+    
+    func testRTrimmedForSet () {
+        XCTAssertEqual("ab   ".rtrimmed(NSCharacterSet.alphanumericCharacterSet()), "ab   ")
+        XCTAssertEqual("  ab".rtrimmed(NSCharacterSet.alphanumericCharacterSet()), "  ")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -196,7 +196,9 @@ Name | Signature
 **`matches`**|`matches (pattern: String, ignoreCase: Bool = false) -> [NSTextCheckingResult]?`
 **`insert`**|`insert (index: Int, _ string: String) -> String`
 **`ltrimmed`**|`ltrimmed () -> String`
+**`ltrimmed`**|`ltrimmed (set: NSCharacterSet) -> String`
 **`rtrimmed`**|`rtrimmed () -> String`
+**`rtrimmed`**|`rtrimmed (set: NSCharacterSet) -> String`
 **`trimmed`**|`trimmed () -> String`
 
 #### Class Methods ####


### PR DESCRIPTION
Inspired by .NET’s TrimStart and TrimEnd methods, I have added the possibility to specify characters to be trimmed, instead of only having the ability to trim white spaces. The latter is still the default behavior so it is backwards compatible with the master branch.