### PR TITLE
Add toNumeric (e.g. toDouble) conversions to string extensions

### DIFF
--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -209,8 +209,12 @@ public extension String {
     }
 
 
+    /**
+        Parses a string containing a double numerical value into an optional double if the string is a well formed number.
+
+        :returns: A double parsed from the string or nil if it cannot be parsed.
+    */
     func toDouble() -> Double? {
-        // regex:
 
         let pattern = "^[-+]?[0-9]*\\.?[0-9]+$"
 
@@ -227,9 +231,45 @@ public extension String {
         return nil
     }
 
+    ///
+    ///    Parses a string containing a float numerical value into an optional float if the string is a well formed number.
+    ///
+    ///    :returns: A float parsed from the string or nil if it cannot be parsed.
+    ///
     func toFloat() -> Float? {
         if let val = self.toDouble() {
             return Float(val)
+        }
+
+        return nil
+    }
+
+    ///
+    ///    Parses a string containing a non-negative integer value into an optional UInt if the string is a well formed number.
+    ///
+    ///    :returns: A UInt parsed from the string or nil if it cannot be parsed.
+    ///
+    func toUInt() -> UInt? {
+        if let val = self.trimmed().toInt() {
+            if val < 0 {
+                return nil
+            }
+            return UInt(val)
+        }
+
+        return nil
+    }
+
+
+    ///
+    /// Parses a string containing a boolean value (true or false) into an optional Bool if the string is a well formed.
+    ///
+    /// :returns: A Bool parsed from the string or nil if it cannot be parsed as a boolean.
+    ///
+    func toBool() -> Bool? {
+        let text = self.trimmed().lowercaseString
+        if text == "true" || text == "false" {
+            return (text as NSString).boolValue
         }
 
         return nil

--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -231,11 +231,11 @@ public extension String {
         return nil
     }
 
-    ///
-    ///    Parses a string containing a float numerical value into an optional float if the string is a well formed number.
-    ///
-    ///    :returns: A float parsed from the string or nil if it cannot be parsed.
-    ///
+    /**
+       Parses a string containing a float numerical value into an optional float if the string is a well formed number.
+
+       :returns: A float parsed from the string or nil if it cannot be parsed.
+    */
     func toFloat() -> Float? {
         if let val = self.toDouble() {
             return Float(val)
@@ -244,11 +244,11 @@ public extension String {
         return nil
     }
 
-    ///
-    ///    Parses a string containing a non-negative integer value into an optional UInt if the string is a well formed number.
-    ///
-    ///    :returns: A UInt parsed from the string or nil if it cannot be parsed.
-    ///
+    /**
+        Parses a string containing a non-negative integer value into an optional UInt if the string is a well formed number.
+
+        :returns: A UInt parsed from the string or nil if it cannot be parsed.
+    */
     func toUInt() -> UInt? {
         if let val = self.trimmed().toInt() {
             if val < 0 {
@@ -261,11 +261,11 @@ public extension String {
     }
 
 
-    ///
-    /// Parses a string containing a boolean value (true or false) into an optional Bool if the string is a well formed.
-    ///
-    /// :returns: A Bool parsed from the string or nil if it cannot be parsed as a boolean.
-    ///
+    /**
+      Parses a string containing a boolean value (true or false) into an optional Bool if the string is a well formed.
+
+      :returns: A Bool parsed from the string or nil if it cannot be parsed as a boolean.
+    */
     func toBool() -> Bool? {
         let text = self.trimmed().lowercaseString
         if text == "true" || text == "false" || text == "yes" || text == "no" {
@@ -273,6 +273,32 @@ public extension String {
         }
 
         return nil
+    }
+
+    /**
+      Parses a string containing a date into an optional NSDate if the string is a well formed.
+      The default format is yyyy-MM-dd, but can be overriden.
+
+      :returns: A NSDate parsed from the string or nil if it cannot be parsed as a date.
+    */
+    func toDate(format : String? = "yyyy-MM-dd") -> NSDate? {
+        let text = self.trimmed().lowercaseString
+        var dateFmt = NSDateFormatter()
+        dateFmt.timeZone = NSTimeZone.defaultTimeZone()
+        if let fmt = format {
+            dateFmt.dateFormat = fmt
+        }
+        return dateFmt.dateFromString(text)
+    }
+
+    /**
+      Parses a string containing a date and time into an optional NSDate if the string is a well formed.
+      The default format is yyyy-MM-dd hh-mm-ss, but can be overriden.
+
+      :returns: A NSDate parsed from the string or nil if it cannot be parsed as a date.
+    */
+    func toDateTime(format : String? = "yyyy-MM-dd hh-mm-ss") -> NSDate? {
+        return toDate(format: format)
     }
 
 }

--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -227,6 +227,14 @@ public extension String {
         return nil
     }
 
+    func toFloat() -> Float? {
+        if let val = self.toDouble() {
+            return Float(val)
+        }
+
+        return nil
+    }
+
 }
 
 /**

--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -208,6 +208,24 @@ public extension String {
 
     }
 
+
+    func toDouble() -> Double? {
+        // regex:
+
+        let pattern = "^[-+]?[0-9]*\\.?[0-9]+$"
+
+        if let regex = ExSwift.regex(pattern, ignoreCase: true) {
+            // Using map to prevent a possible bug in the compiler
+            if regex.matchesInString(self, options: nil, range: NSMakeRange(0, length)).isEmpty {
+                return nil
+            }
+
+            return (self as NSString).doubleValue
+        }
+
+        return nil
+    }
+
 }
 
 /**

--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -268,7 +268,7 @@ public extension String {
     ///
     func toBool() -> Bool? {
         let text = self.trimmed().lowercaseString
-        if text == "true" || text == "false" {
+        if text == "true" || text == "false" || text == "yes" || text == "no" {
             return (text as NSString).boolValue
         }
 

--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -215,8 +215,9 @@ public extension String {
         let pattern = "^[-+]?[0-9]*\\.?[0-9]+$"
 
         if let regex = ExSwift.regex(pattern, ignoreCase: true) {
-            // Using map to prevent a possible bug in the compiler
-            if regex.matchesInString(self, options: nil, range: NSMakeRange(0, length)).isEmpty {
+            let text = self.trimmed()
+            let matches = regex.matchesInString(text, options: nil, range: NSMakeRange(0, countElements(text)))
+            if matches.isEmpty {
                 return nil
             }
 

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -151,4 +151,16 @@ class ExSwiftStringTests: XCTestCase {
 
        XCTAssertNil("a772.2".toDouble())
     }
+
+
+
+    func testToFloat() {
+        var f : Float = "  7.2 ".toFloat()!
+        XCTAssertEqual(Float(7.2), f)
+
+        f = "-70.211111".toFloat()!
+        XCTAssertEqual(Float(-70.211111), f)
+
+        XCTAssertNil("a772.2".toFloat())
+    }
 }

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -115,6 +115,7 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertEqual("t e".trimmed(), "t e")
         XCTAssertEqual(" AB".trimmed(), "AB")
         XCTAssertEqual("\n ABC   ".trimmed(), "ABC")
+
     }
     
     func testLTrimmed () {
@@ -142,7 +143,7 @@ class ExSwiftStringTests: XCTestCase {
     }
 
     func testToDouble() {
-        var d : Double = "7.2".toDouble()!
+        var d : Double = "  7.2 ".toDouble()!
         XCTAssertEqual(7.2, d)
 
         d = "-70.211111".toDouble()!

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -177,8 +177,12 @@ class ExSwiftStringTests: XCTestCase {
     func testToBool() {
         var b = "  TrUe ".toBool()!
         XCTAssertEqual(true, b)
+        b = "  yEs ".toBool()!
+        XCTAssertEqual(true, b)
 
         b = "  FALSE ".toBool()!
+        XCTAssertEqual(false, b)
+        b = "  nO ".toBool()!
         XCTAssertEqual(false, b)
 
         XCTAssertNil("".toBool())

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -140,4 +140,14 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertEqual("ab   ".rtrimmed(NSCharacterSet.alphanumericCharacterSet()), "ab   ")
         XCTAssertEqual("  ab".rtrimmed(NSCharacterSet.alphanumericCharacterSet()), "  ")
     }
+
+    func testToDouble() {
+        var d : Double = "7.2".toDouble()!
+        XCTAssertEqual(7.2, d)
+
+        d = "-70.211111".toDouble()!
+        XCTAssertEqual(-70.211111, d)
+
+       XCTAssertNil("a772.2".toDouble())
+    }
 }

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -189,4 +189,43 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertNil("jeff".toBool())
         XCTAssertNil("0".toBool())
     }
+
+    func testToDate() {
+        var d : NSDate = " 2015-08-19 \t ".toDate()!
+
+        var c = NSDateComponents()
+        c.year = 2015
+        c.month = 8
+        c.day = 19
+
+        var gregorian = NSCalendar(identifier:NSGregorianCalendar)!
+        var expected = gregorian.dateFromComponents(c)!
+
+        XCTAssertEqual(expected, d)
+
+        XCTAssertNil("a772.2".toDate())
+        XCTAssertNil("Tuesday".toDate())
+        XCTAssertNil("1973-08-19 03:04:55".toDate())
+    }
+
+    func testToDateTime() {
+        var d : NSDate = " 2015-08-19 03:04:34\t ".toDateTime()!
+
+        var c = NSDateComponents()
+        c.year = 2015
+        c.month = 8
+        c.day = 19
+        c.hour = 3
+        c.minute = 4
+        c.second = 34
+
+        var gregorian = NSCalendar(identifier:NSGregorianCalendar)!
+        var expected = gregorian.dateFromComponents(c)!
+
+        XCTAssertEqual(expected, d)
+
+        XCTAssertNil("a772.2".toDateTime())
+        XCTAssertNil("Tuesday".toDateTime())
+        XCTAssertNil("1973-08-19".toDateTime())
+    }
 }

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -149,10 +149,11 @@ class ExSwiftStringTests: XCTestCase {
         d = "-70.211111".toDouble()!
         XCTAssertEqual(-70.211111, d)
 
+        d = "42".toDouble()!
+        XCTAssertEqual(42, d)
+
        XCTAssertNil("a772.2".toDouble())
     }
-
-
 
     func testToFloat() {
         var f : Float = "  7.2 ".toFloat()!
@@ -162,5 +163,26 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertEqual(Float(-70.211111), f)
 
         XCTAssertNil("a772.2".toFloat())
+    }
+
+    func testToUInt() {
+        var u : UInt = "  7 ".toUInt()!
+        XCTAssertEqual(UInt(7), u)
+
+        XCTAssertNil("a772.2".toUInt())
+        XCTAssertNil("-772".toUInt())
+        XCTAssertNil("7.5".toUInt())
+    }
+
+    func testToBool() {
+        var b = "  TrUe ".toBool()!
+        XCTAssertEqual(true, b)
+
+        b = "  FALSE ".toBool()!
+        XCTAssertEqual(false, b)
+
+        XCTAssertNil("".toBool())
+        XCTAssertNil("jeff".toBool())
+        XCTAssertNil("0".toBool())
     }
 }


### PR DESCRIPTION
I have added 4 new methods to the string extension class. 

* toDouble() -> Double?
* toFloat() -> Float?
* toUInt() -> UInt?
* toBool() -> Bool?

They are meant to have the same semantics as the built-in String.toInt() method but for the respective types and are more robust (e.g. "\t 7.2".toDouble() will parse successfully).

I have also added associated unit tests.

I have not yet added the methods to the docs (but they do have doc strings in code). I'm happy to do this if you want.

Please contact me if you have questions.

Thanks,
Michael
