### PR TITLE
Trimmed methods fail on string that contains only whitespace

### DIFF
--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -150,7 +150,7 @@ public extension String {
             return self[range.startIndex..<endIndex]
         }
         
-        return self
+        return ""
     }
 
     /**
@@ -172,7 +172,7 @@ public extension String {
             return self[startIndex..<range.endIndex]
         }
         
-        return self
+        return ""
     }
 
     /**

--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -115,6 +115,8 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertEqual("t e".trimmed(), "t e")
         XCTAssertEqual(" AB".trimmed(), "AB")
         XCTAssertEqual("\n ABC   ".trimmed(), "ABC")
+        XCTAssertEqual("".trimmed(), "")
+        XCTAssertEqual(" \t\n\r".trimmed(), "")
     }
     
     func testLTrimmed () {
@@ -122,6 +124,8 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertEqual("ab".ltrimmed(), "ab")
         XCTAssertEqual(" AB".ltrimmed(), "AB")
         XCTAssertEqual("\n ABC   ".ltrimmed(), "ABC   ")
+        XCTAssertEqual("".ltrimmed(), "")
+        XCTAssertEqual(" \t\n\r".ltrimmed(), "")
     }
     
     func testRTrimmed () {
@@ -129,15 +133,19 @@ class ExSwiftStringTests: XCTestCase {
         XCTAssertEqual(" AB".rtrimmed(), " AB")
         XCTAssertEqual("AB ".rtrimmed(), "AB")
         XCTAssertEqual("\n ABC   ".rtrimmed(), "\n ABC")
+        XCTAssertEqual("".rtrimmed(), "")
+        XCTAssertEqual(" \t\n\r".rtrimmed(), "")
     }
     
     func testLTrimmedForSet () {
         XCTAssertEqual("ab   ".ltrimmed(NSCharacterSet.alphanumericCharacterSet()), "   ")
         XCTAssertEqual("  ab".ltrimmed(NSCharacterSet.alphanumericCharacterSet()), "  ab")
+        XCTAssertEqual("ab".ltrimmed(NSCharacterSet.alphanumericCharacterSet()), "")
     }
     
     func testRTrimmedForSet () {
         XCTAssertEqual("ab   ".rtrimmed(NSCharacterSet.alphanumericCharacterSet()), "ab   ")
         XCTAssertEqual("  ab".rtrimmed(NSCharacterSet.alphanumericCharacterSet()), "  ")
+        XCTAssertEqual("ab".rtrimmed(NSCharacterSet.alphanumericCharacterSet()), "")
     }
 }


### PR DESCRIPTION
Strangely, `ltrimmed()`, `rtrimmed()` and `trimmed()` each return the original string when asked to process a string that contains only whitespace, via the Swift REPL:
```sh
 28> "  ".ltrimmed()
$R0: String = "  "
 29> "  ".rtrimmed()
$R1: String = "  "
 30> "  ".trimmed()
$R2: String = "  "
```

The implementation uses `rangeOfCharacterFromSet(_: options: range:)` which returns `Range<String.Index>?`:
```swift
func ltrimmed (set: NSCharacterSet) -> String {
    if let range = rangeOfCharacterFromSet(set.invertedSet) {
        return self[range.startIndex..<endIndex]
    }
    
    return self // 👈
}

func rtrimmed (set: NSCharacterSet) -> String {
    if let range = rangeOfCharacterFromSet(set.invertedSet, options: NSStringCompareOptions.BackwardsSearch) {
        return self[startIndex..<range.endIndex]
    }
    
    return self // 👈
}
```

So when the optional `nil`is returned there aren't *any* characters from the inverted set encountered - in which case an empty sting should be returned no?

This holds for not just whitespace but also when using the `set` trimmed variations like in the updated tests:
```swift
XCTAssertEqual("ab".ltrimmed(NSCharacterSet.alphanumericCharacterSet()), "")
```