### PR TITLE
mapAccum for Array

### DIFF
--- a/ExSwift/Array.swift
+++ b/ExSwift/Array.swift
@@ -840,6 +840,27 @@ internal extension Array {
     }
     
     /**
+        Creates an array with values and an accumulated result by running accumulated result
+        and each value of self through the mapFunction.
+    
+        :param: initial Initial value for accumulator
+        :param: mapFunction
+        :returns: Accumulated value and mapped array
+    */
+    func mapAccum <U, V> (initial: U, mapFunction map: (U, Element) -> (U, V)) -> (U, [V]) {
+        var mapped = [V]()
+        var acc = initial
+        
+        each { (value: Element) -> Void in
+            let (mappedAcc, mappedValue) = map(acc, value)
+            acc = mappedAcc
+            mapped.append(mappedValue)
+        }
+        
+        return (acc, mapped)
+    }
+    
+    /**
         self.reduce with initial value self.first()
     */
     func reduce (combine: (Element, Element) -> Element) -> Element? {

--- a/ExSwiftTests/ExSwiftArrayTests.swift
+++ b/ExSwiftTests/ExSwiftArrayTests.swift
@@ -394,6 +394,15 @@ class ExtensionsArrayTests: XCTestCase {
         XCTAssertEqual(m, [2, 3, 4])
     }
     
+    func testMapAccum() {
+        let m:(Int, [Int]) = array.mapAccum(0) { acc, value in
+            return (acc + value, value * 2)
+        }
+        
+        XCTAssertEqual(m.0, 15)
+        XCTAssertEqual(m.1, [2, 4, 6, 8, 10])
+    }
+    
     func testSubscriptConflicts() {
         let array1 = ["zero", "one", "two", "three"][rangeAsArray: 1...3]
         let array2 = ["zero", "one", "two", "three"][rangeAsArray: 1..<3]


### PR DESCRIPTION
Sometimes when you are mapping through an array you need an accumulated value that influences the mapping. The `mapAccum` function provided in this PR gives you this functionality. It is basically a combination of map and reduce. 