### PR TITLE
Add getter and comparison to NSDate

### DIFF
--- a/ExSwift/NSDate.swift
+++ b/ExSwift/NSDate.swift
@@ -133,13 +133,19 @@ public extension NSDate{
     
     // MARK: Getter
     
+    /**
+    Date year
+    */
     public var year : Int {
     
         get {
             return getComponent(.CalendarUnitYear)
         }
     }
-    
+
+    /**
+    Date month
+    */
     public var month : Int {
         
         get {
@@ -147,6 +153,9 @@ public extension NSDate{
         }
     }
     
+    /**
+    Date weekday
+    */
     public var weekday : Int {
         
         get {
@@ -154,6 +163,9 @@ public extension NSDate{
         }
     }
 
+    /**
+    Date weekMonth
+    */
     public var weekMonth : Int {
         
         get {
@@ -162,6 +174,9 @@ public extension NSDate{
     }
 
     
+    /**
+    Date days
+    */
     public var days : Int {
         
         get {
@@ -169,6 +184,9 @@ public extension NSDate{
         }
     }
     
+    /**
+    Date hours
+    */
     public var hours : Int {
         
         get {
@@ -176,6 +194,9 @@ public extension NSDate{
         }
     }
     
+    /**
+    Date minuts
+    */
     public var minutes : Int {
         
         get {
@@ -183,6 +204,9 @@ public extension NSDate{
         }
     }
     
+    /**
+    Date seconds
+    */
     public var seconds : Int {
         
         get {
@@ -190,12 +214,16 @@ public extension NSDate{
         }
     }
     
+    /**
+    Returns the value of the NSDate component
+    
+    :param: component NSCalendarUnit
+    :returns: the value of the component
+    */
+
     public func getComponent (component : NSCalendarUnit) -> Int {
         let calendar = NSCalendar.currentCalendar()
         let components = calendar.components(component, fromDate: self)
         return components.valueForComponent(component)
     }
-
-    
-    
 }

--- a/ExSwift/NSDate.swift
+++ b/ExSwift/NSDate.swift
@@ -131,4 +131,71 @@ public extension NSDate{
     }
     
     
+    // MARK: Getter
+    
+    public var year : Int {
+    
+        get {
+            return getComponent(.CalendarUnitYear)
+        }
+    }
+    
+    public var month : Int {
+        
+        get {
+            return getComponent(.CalendarUnitMonth)
+        }
+    }
+    
+    public var weekday : Int {
+        
+        get {
+            return getComponent(.CalendarUnitWeekday)
+        }
+    }
+
+    public var weekMonth : Int {
+        
+        get {
+            return getComponent(.CalendarUnitWeekOfMonth)
+        }
+    }
+
+    
+    public var days : Int {
+        
+        get {
+            return getComponent(.CalendarUnitDay)
+        }
+    }
+    
+    public var hours : Int {
+        
+        get {
+            return getComponent(.CalendarUnitHour)
+        }
+    }
+    
+    public var minutes : Int {
+        
+        get {
+            return getComponent(.CalendarUnitMinute)
+        }
+    }
+    
+    public var seconds : Int {
+        
+        get {
+            return getComponent(.CalendarUnitSecond)
+        }
+    }
+    
+    public func getComponent (component : NSCalendarUnit) -> Int {
+        let calendar = NSCalendar.currentCalendar()
+        let components = calendar.components(component, fromDate: self)
+        return components.valueForComponent(component)
+    }
+
+    
+    
 }

--- a/ExSwift/NSDate.swift
+++ b/ExSwift/NSDate.swift
@@ -227,3 +227,28 @@ public extension NSDate{
         return components.valueForComponent(component)
     }
 }
+
+// MARK: Comparable functions
+
+public func ==(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs.compare(rhs) == NSComparisonResult.OrderedSame
+}
+
+public func <(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs.compare(rhs) == NSComparisonResult.OrderedAscending
+}
+
+public func >(lhs: NSDate, rhs: NSDate) -> Bool {
+    return !(lhs < rhs)
+}
+
+public func <=(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs < rhs || lhs == rhs
+}
+
+public func >=(lhs: NSDate, rhs: NSDate) -> Bool {
+    return lhs > rhs || lhs == rhs
+}
+
+extension NSDate: Comparable {
+}

--- a/ExSwift/NSDate.swift
+++ b/ExSwift/NSDate.swift
@@ -224,6 +224,7 @@ public extension NSDate{
     public func getComponent (component : NSCalendarUnit) -> Int {
         let calendar = NSCalendar.currentCalendar()
         let components = calendar.components(component, fromDate: self)
+
         return components.valueForComponent(component)
     }
 }
@@ -239,7 +240,7 @@ public func <(lhs: NSDate, rhs: NSDate) -> Bool {
 }
 
 public func >(lhs: NSDate, rhs: NSDate) -> Bool {
-    return !(lhs < rhs)
+    return !(lhs <= rhs)
 }
 
 public func <=(lhs: NSDate, rhs: NSDate) -> Bool {

--- a/ExSwiftTests/ExSwiftNSDateTests.swift
+++ b/ExSwiftTests/ExSwiftNSDateTests.swift
@@ -206,9 +206,11 @@ class ExSwiftNSDataTests: XCTestCase {
 
         XCTAssertTrue(startDate > date, "Date should be greater")
         XCTAssertFalse(startDate > anotherDate, "Date shouldn't be greater")
+        XCTAssertFalse(startDate > shouldBeTheSameDate, "Date shouldn't be greater")
         
         XCTAssertTrue(startDate < anotherDate, "Date should be lower")
         XCTAssertFalse(startDate < date, "Date shouldn't be lower")
+        XCTAssertFalse(startDate < shouldBeTheSameDate, "Date shouldn't be lower")
 
         XCTAssertTrue(startDate >= shouldBeTheSameDate, "Date should be greater or equal")
         XCTAssertTrue(startDate >= date, "Date should be greater or equal")

--- a/ExSwiftTests/ExSwiftNSDateTests.swift
+++ b/ExSwiftTests/ExSwiftNSDateTests.swift
@@ -159,4 +159,15 @@ class ExSwiftNSDataTests: XCTestCase {
         
     }
     
+    func testGetter() {
+        XCTAssertEqual(1988, startDate!.year, "Year Mismatch")
+        XCTAssertEqual(11, startDate!.month, "Month Mismatch")
+        XCTAssertEqual(30, startDate!.days, "Day Mismatch")
+        XCTAssertEqual(0, startDate!.hours, "Hours Mismatch")
+        XCTAssertEqual(0, startDate!.minutes, "Minutes Mismatch")
+        XCTAssertEqual(0, startDate!.seconds, "Seconds Mismatch")
+        XCTAssertEqual(4, startDate!.weekday, "Weekmonth Mismatch")
+        XCTAssertEqual(5, startDate!.weekMonth, "Weekmonth Mismatch")
+    }
+    
 }

--- a/ExSwiftTests/ExSwiftNSDateTests.swift
+++ b/ExSwiftTests/ExSwiftNSDateTests.swift
@@ -148,7 +148,7 @@ class ExSwiftNSDataTests: XCTestCase {
         XCTAssertFalse(date.isAfter(date), "Past date should be in the past")
         XCTAssertFalse(pastDate.isAfter(date), "Past date should be in the past")
     }
-    
+
     func testIsBefore(){
         var date = NSDate()
         var futureDate = date.addSeconds(42)
@@ -158,6 +158,8 @@ class ExSwiftNSDataTests: XCTestCase {
         XCTAssertFalse(date.isAfter(date), "Past date should be in the past")
         
     }
+    
+    // MARK:  Getter
     
     func testGetter() {
         XCTAssertEqual(1988, startDate!.year, "Year Mismatch")
@@ -170,4 +172,54 @@ class ExSwiftNSDataTests: XCTestCase {
         XCTAssertEqual(5, startDate!.weekMonth, "Weekmonth Mismatch")
     }
     
+    // MARK: Comparable
+    
+    func testSorting () {
+        var firstDate = startDate!.addSeconds(0)
+        var secondDate = startDate!.addSeconds(42)
+        var thirdDate = startDate!.addSeconds(-42)
+        var fourthDate = startDate!.addSeconds(-84)
+        var fifthDate = startDate!.addSeconds(84)
+        
+        var dates : [NSDate] = [thirdDate, secondDate, firstDate, fourthDate, fifthDate]
+        
+        let expected : [NSDate] = [fifthDate, secondDate, firstDate, thirdDate, fourthDate]
+
+        let expectedReverded = expected.reverse()
+        
+        for i in 0 ... 42 {
+            dates.shuffle()
+        
+            dates.sort( { $0 > $1 } )
+            XCTAssertEqual(expected, dates, "Sort mismatch")
+        
+            dates.sort( { $0 < $1 } )
+            XCTAssertEqual(expectedReverded, dates, "Sort mismatch")
+        }
+    }
+    
+    func testComparable(){
+        var date = startDate!.addSeconds(-42)
+        var anotherDate = startDate!.addSeconds(42)
+        let shouldBeTheSameDate = NSDate(timeInterval: 0, sinceDate: startDate!)
+
+
+        XCTAssertTrue(startDate > date, "Date should be greater")
+        XCTAssertFalse(startDate > anotherDate, "Date shouldn't be greater")
+        
+        XCTAssertTrue(startDate < anotherDate, "Date should be lower")
+        XCTAssertFalse(startDate < date, "Date shouldn't be lower")
+
+        XCTAssertTrue(startDate >= shouldBeTheSameDate, "Date should be greater or equal")
+        XCTAssertTrue(startDate >= date, "Date should be greater or equal")
+        XCTAssertFalse(startDate >= anotherDate, "Date shouldn't be greater or equal")
+        
+        XCTAssertTrue(startDate <= shouldBeTheSameDate, "Date should be lower or equal")
+        XCTAssertTrue(startDate < anotherDate, "Date should be lower")
+        XCTAssertFalse(startDate <= date, "Date shouldn't be greater or equal")
+        
+        XCTAssertFalse(date == startDate, "Date should mismatch")
+        XCTAssertFalse(anotherDate == startDate, "Date should mismatch")
+        XCTAssertTrue(shouldBeTheSameDate == startDate, "Date shouldn't mismatch")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -356,6 +356,47 @@ Name | Signatures
 **`bind`**|`bind <P, T> (function: (P...) -> T, _ parameters: P...) -> (() -> T)`
 **`cached`**|`cached <P, R> (function: (P...) -> R) -> ((P...) -> R)`<br>`cached <P, R> (function: (P...) -> R, hash: ((P...) -> P)) -> ((P...) -> R)`
 
+# NSDate #
+
+#### Properties ####
+Name | Signatures
+---- | ---- 
+**`year`** |`Int`
+**`month`**|`Int`
+**`weekday`** |`Int`
+**`weekMonth`**|`Int`
+**`days`** |`Int`
+**`hours`**|`Int`
+**`minutes`** |`Int`
+**`seconds`**| `Int`
+
+#### Instance Methods ####
+Name | Signatures
+---- | ----------
+**`add`**|`add(seconds:Int=0, minutes:Int = 0, hours:Int = 0, days:Int = 0, weeks:Int = 0, months:Int = 0, years:Int = 0) -> NSDate`
+**`addSeconds`**|`addSeconds (seconds:Int) -> NSDate `
+**`addMinutes`**|`addMinutes (minute:Int) -> NSDate `
+**`addHours`**|`addHours(hours:Int) -> NSDate `
+**`addDays`**|`addDays(days:Int) -> NSDate `
+**`addWeeks`**|`addWeeks(weeks:Int) -> NSDate`
+**`addMonths`**|`addMonths(months:Int) -> NSDate`
+**`addYears`**|`addYears(years:Int) -> NSDate `
+**`isAfter`**|`isAfter(date: NSDate) -> Bool`
+**`isBefore`**|`isBefore(date: NSDate) -> Bool`
+**`getComponent`**|`getComponent (component : NSCalendarUnit) -> Int`
+
+#### Operators ####
+
+Name | Signatures
+---- | ----------
+**`==`**|`==(lhs: NSDate, rhs: NSDate) -> Bool`
+**`<`**|`<(lhs: NSDate, rhs: NSDate) -> Bool`
+**`>`**|`>(lhs: NSDate, rhs: NSDate) -> Bool`
+**`<=`**|`<=(lhs: NSDate, rhs: NSDate) -> Bool`
+**`>=`**|`>=(lhs: NSDate, rhs: NSDate) -> Bool`
+**`==`**|`==(lhs: NSDate, rhs: NSDate) -> Bool`
+
+
 # To Do #
 * [X] Wiki
 * [X] Xcode project for both iOS & OS X


### PR DESCRIPTION
Hi,

I have added getters to NSDate. Now you can do:

```swift
let date = NSDate()
let year = date.year
```
instead of 

```swift
let date = NSDate()
let calendar = NSCalendar.currentCalendar()
let components = calendar.components(.CalendarUnitYear, fromDate: date)
let year = components.year
```

I have also added Comparison operator: <, <=, >, >=, == and updated the docs and README.md



