### PR TITLE
Fix compiler errors in second Xcode 6.3 beta (6D532l).

### DIFF
--- a/ExSwift/Array.swift
+++ b/ExSwift/Array.swift
@@ -185,10 +185,10 @@ internal extension Array {
 
         //  If the index is out of bounds it's assumed relative
         func relativeIndex (index: Int) -> Int {
-            var _index = (index % count)
+            var _index = (index % self.count)
 
             if _index < 0 {
-                _index = count + _index
+                _index = self.count + _index
             }
 
             return _index

--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -91,9 +91,9 @@ public extension String {
         :returns: Array of substrings
     */
     func explode (separator: Character) -> [String] {
-        return split(self, { (element: Character) -> Bool in
+        return split(self) { (element: Character) -> Bool in
             return element == separator
-        })
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes two issues with the latest Xcode 6.3 beta.

I was unable to build and run the tests, however (due to a compiler crash).