### PR TITLE
Remove Deprecation Warnings

### DIFF
--- a/ExSwiftTests/ExSwiftStringTests.swift
+++ b/ExSwiftTests/ExSwiftStringTests.swift
@@ -205,7 +205,7 @@ class ExSwiftStringTests: XCTestCase {
         c.month = 8
         c.day = 19
 
-        var gregorian = NSCalendar(identifier:NSGregorianCalendar)!
+        var gregorian = NSCalendar(identifier:NSCalendarIdentifierGregorian)!
         var expected = gregorian.dateFromComponents(c)!
 
         XCTAssertEqual(expected, d)
@@ -226,7 +226,7 @@ class ExSwiftStringTests: XCTestCase {
         c.minute = 4
         c.second = 34
 
-        var gregorian = NSCalendar(identifier:NSGregorianCalendar)!
+        var gregorian = NSCalendar(identifier:NSCalendarIdentifierGregorian)!
         var expected = gregorian.dateFromComponents(c)!
 
         XCTAssertEqual(expected, d)


### PR DESCRIPTION
Previously, the `EXSwiftStringTests` were generating a warning about the use of `NSGregorianCalendar` which was deprecated in iOS8.  This change updates the use of `NSGregorianCalendar` to `NSCalendarIdentifierGregorian`.