### PR TITLE
Enhance Carthage Support

### DIFF
--- a/ExSwift.xcodeproj/project.pbxproj
+++ b/ExSwift.xcodeproj/project.pbxproj
@@ -30,6 +30,44 @@
 		1EC241FC1946E91B0047109A /* NSArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC241FB1946E91B0047109A /* NSArray.swift */; };
 		1EC241FE1946E92E0047109A /* ExSwiftNSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC241FD1946E92E0047109A /* ExSwiftNSArrayTests.swift */; };
 		1ED536841943863100BDA94E /* ExSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED536831943863100BDA94E /* ExSwift.swift */; };
+		24D9BBF11AC54B31000FDBB8 /* ExSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 24D9BBE61AC54B30000FDBB8 /* ExSwift.framework */; };
+		24D9BBFF1AC54BCF000FDBB8 /* ExSwift.h in Headers */ = {isa = PBXBuildFile; fileRef = 1E11AF891943222D006BCE48 /* ExSwift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		24D9BC001AC54C1C000FDBB8 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0AB977195C7FAF0009BDA0 /* Sequence.swift */; };
+		24D9BC011AC54C1C000FDBB8 /* ExSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED536831943863100BDA94E /* ExSwift.swift */; };
+		24D9BC021AC54C1C000FDBB8 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAC1943225B006BCE48 /* Array.swift */; };
+		24D9BC031AC54C1C000FDBB8 /* Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8C1D701A365CA6003D386E /* Character.swift */; };
+		24D9BC041AC54C1C000FDBB8 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAD1943225B006BCE48 /* Dictionary.swift */; };
+		24D9BC051AC54C1C000FDBB8 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E48E61D1973ED07006FEEC8 /* Double.swift */; };
+		24D9BC061AC54C1C000FDBB8 /* Float.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAE1943225B006BCE48 /* Float.swift */; };
+		24D9BC071AC54C1C000FDBB8 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAF1943225B006BCE48 /* Int.swift */; };
+		24D9BC081AC54C1C000FDBB8 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFB01943225B006BCE48 /* Range.swift */; };
+		24D9BC091AC54C1C000FDBB8 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFB11943225B006BCE48 /* String.swift */; };
+		24D9BC0A1AC54C1C000FDBB8 /* NSArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC241FB1946E91B0047109A /* NSArray.swift */; };
+		24D9BC0B1AC54C1C000FDBB8 /* NSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12168FC91A22852300ED4105 /* NSDate.swift */; };
+		24D9BC0C1AC54C2B000FDBB8 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0AB977195C7FAF0009BDA0 /* Sequence.swift */; };
+		24D9BC0D1AC54C2B000FDBB8 /* ExSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED536831943863100BDA94E /* ExSwift.swift */; };
+		24D9BC0E1AC54C2B000FDBB8 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAC1943225B006BCE48 /* Array.swift */; };
+		24D9BC0F1AC54C2B000FDBB8 /* Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8C1D701A365CA6003D386E /* Character.swift */; };
+		24D9BC101AC54C2B000FDBB8 /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAD1943225B006BCE48 /* Dictionary.swift */; };
+		24D9BC111AC54C2B000FDBB8 /* Double.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E48E61D1973ED07006FEEC8 /* Double.swift */; };
+		24D9BC121AC54C2B000FDBB8 /* Float.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAE1943225B006BCE48 /* Float.swift */; };
+		24D9BC131AC54C2B000FDBB8 /* Int.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAF1943225B006BCE48 /* Int.swift */; };
+		24D9BC141AC54C2B000FDBB8 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFB01943225B006BCE48 /* Range.swift */; };
+		24D9BC151AC54C2B000FDBB8 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFB11943225B006BCE48 /* String.swift */; };
+		24D9BC161AC54C2B000FDBB8 /* NSArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC241FB1946E91B0047109A /* NSArray.swift */; };
+		24D9BC171AC54C2B000FDBB8 /* NSDate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12168FC91A22852300ED4105 /* NSDate.swift */; };
+		24D9BC181AC54C32000FDBB8 /* ExSwiftSequenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C0AB97C195C7FBC0009BDA0 /* ExSwiftSequenceTests.swift */; };
+		24D9BC191AC54C32000FDBB8 /* ExSwiftArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFA019432236006BCE48 /* ExSwiftArrayTests.swift */; };
+		24D9BC1A1AC54C32000FDBB8 /* ExSwiftCharacterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC633BA51A37142900341557 /* ExSwiftCharacterTests.swift */; };
+		24D9BC1B1AC54C32000FDBB8 /* ExSwiftDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFA119432236006BCE48 /* ExSwiftDictionaryTests.swift */; };
+		24D9BC1C1AC54C32000FDBB8 /* ExSwiftDoubleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E48E6221973ED22006FEEC8 /* ExSwiftDoubleTests.swift */; };
+		24D9BC1D1AC54C32000FDBB8 /* ExSwiftFloatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFA219432236006BCE48 /* ExSwiftFloatTests.swift */; };
+		24D9BC1E1AC54C32000FDBB8 /* ExSwiftIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFA319432236006BCE48 /* ExSwiftIntTests.swift */; };
+		24D9BC1F1AC54C32000FDBB8 /* ExSwiftRangeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFA419432236006BCE48 /* ExSwiftRangeTests.swift */; };
+		24D9BC201AC54C32000FDBB8 /* ExSwiftStringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFA519432236006BCE48 /* ExSwiftStringTests.swift */; };
+		24D9BC211AC54C32000FDBB8 /* ExSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EA5F689194387CA00E8A40F /* ExSwiftTests.swift */; };
+		24D9BC221AC54C32000FDBB8 /* ExSwiftNSArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC241FD1946E92E0047109A /* ExSwiftNSArrayTests.swift */; };
+		24D9BC231AC54C32000FDBB8 /* ExSwiftNSDateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12168FCC1A2285A900ED4105 /* ExSwiftNSDateTests.swift */; };
 		2EB34F05195473AC00A8D2AF /* ExSwift.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED536831943863100BDA94E /* ExSwift.swift */; };
 		2EB34F06195473AC00A8D2AF /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAC1943225B006BCE48 /* Array.swift */; };
 		2EB34F07195473AC00A8D2AF /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E11AFAD1943225B006BCE48 /* Dictionary.swift */; };
@@ -45,6 +83,16 @@
 		CC633BA71A37144E00341557 /* Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8C1D701A365CA6003D386E /* Character.swift */; };
 		CC8C1D711A365CA6003D386E /* Character.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC8C1D701A365CA6003D386E /* Character.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		24D9BBF21AC54B31000FDBB8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 1E11AF7B1943222D006BCE48 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 24D9BBE51AC54B30000FDBB8;
+			remoteInfo = ExSeift;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		12168FC91A22852300ED4105 /* NSDate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSDate.swift; sourceTree = "<group>"; };
@@ -72,6 +120,8 @@
 		1EC241FB1946E91B0047109A /* NSArray.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSArray.swift; sourceTree = "<group>"; };
 		1EC241FD1946E92E0047109A /* ExSwiftNSArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExSwiftNSArrayTests.swift; sourceTree = "<group>"; };
 		1ED536831943863100BDA94E /* ExSwift.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExSwift.swift; sourceTree = "<group>"; };
+		24D9BBE61AC54B30000FDBB8 /* ExSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ExSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		24D9BBF01AC54B31000FDBB8 /* ExSwiftTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ExSwiftTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C0AB977195C7FAF0009BDA0 /* Sequence.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Sequence.swift; sourceTree = "<group>"; };
 		3C0AB97C195C7FBC0009BDA0 /* ExSwiftSequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExSwiftSequenceTests.swift; sourceTree = "<group>"; };
 		CC633BA51A37142900341557 /* ExSwiftCharacterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExSwiftCharacterTests.swift; sourceTree = "<group>"; };
@@ -93,6 +143,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		24D9BBE21AC54B30000FDBB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		24D9BBED1AC54B31000FDBB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24D9BBF11AC54B31000FDBB8 /* ExSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -110,6 +175,8 @@
 			children = (
 				1E11AF841943222D006BCE48 /* ExSwift.framework */,
 				1E11AF8F1943222D006BCE48 /* ExSwiftTests.xctest */,
+				24D9BBE61AC54B30000FDBB8 /* ExSwift.framework */,
+				24D9BBF01AC54B31000FDBB8 /* ExSwiftTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -182,12 +249,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		24D9BBE31AC54B30000FDBB8 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24D9BBFF1AC54BCF000FDBB8 /* ExSwift.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		1E11AF831943222D006BCE48 /* ExSwift */ = {
+		1E11AF831943222D006BCE48 /* ExSwift-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1E11AF9A1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwift" */;
+			buildConfigurationList = 1E11AF9A1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwift-OSX" */;
 			buildPhases = (
 				1E11AF7F1943222D006BCE48 /* Sources */,
 				1E11AF801943222D006BCE48 /* Frameworks */,
@@ -198,14 +273,14 @@
 			);
 			dependencies = (
 			);
-			name = ExSwift;
+			name = "ExSwift-OSX";
 			productName = ExSwift;
 			productReference = 1E11AF841943222D006BCE48 /* ExSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		1E11AF8E1943222D006BCE48 /* ExSwiftTests */ = {
+		1E11AF8E1943222D006BCE48 /* ExSwiftTests-OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 1E11AF9D1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwiftTests" */;
+			buildConfigurationList = 1E11AF9D1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwiftTests-OSX" */;
 			buildPhases = (
 				1E11AF8B1943222D006BCE48 /* Sources */,
 				1E11AF8C1943222D006BCE48 /* Frameworks */,
@@ -215,9 +290,45 @@
 			);
 			dependencies = (
 			);
-			name = ExSwiftTests;
+			name = "ExSwiftTests-OSX";
 			productName = ExSwiftTests;
 			productReference = 1E11AF8F1943222D006BCE48 /* ExSwiftTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		24D9BBE51AC54B30000FDBB8 /* ExSwift-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 24D9BBF91AC54B31000FDBB8 /* Build configuration list for PBXNativeTarget "ExSwift-iOS" */;
+			buildPhases = (
+				24D9BBE11AC54B30000FDBB8 /* Sources */,
+				24D9BBE21AC54B30000FDBB8 /* Frameworks */,
+				24D9BBE31AC54B30000FDBB8 /* Headers */,
+				24D9BBE41AC54B30000FDBB8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ExSwift-iOS";
+			productName = ExSeift;
+			productReference = 24D9BBE61AC54B30000FDBB8 /* ExSwift.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		24D9BBEF1AC54B31000FDBB8 /* ExSwiftTests-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 24D9BBFC1AC54B31000FDBB8 /* Build configuration list for PBXNativeTarget "ExSwiftTests-iOS" */;
+			buildPhases = (
+				24D9BBEC1AC54B31000FDBB8 /* Sources */,
+				24D9BBED1AC54B31000FDBB8 /* Frameworks */,
+				24D9BBEE1AC54B31000FDBB8 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				24D9BBF31AC54B31000FDBB8 /* PBXTargetDependency */,
+			);
+			name = "ExSwiftTests-iOS";
+			productName = ExSeiftTests;
+			productReference = 24D9BBF01AC54B31000FDBB8 /* ExSwiftTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -236,6 +347,12 @@
 						CreatedOnToolsVersion = 6.0;
 						TestTargetID = 1E11AF831943222D006BCE48;
 					};
+					24D9BBE51AC54B30000FDBB8 = {
+						CreatedOnToolsVersion = 6.3;
+					};
+					24D9BBEF1AC54B31000FDBB8 = {
+						CreatedOnToolsVersion = 6.3;
+					};
 				};
 			};
 			buildConfigurationList = 1E11AF7E1943222D006BCE48 /* Build configuration list for PBXProject "ExSwift" */;
@@ -250,8 +367,10 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				1E11AF831943222D006BCE48 /* ExSwift */,
-				1E11AF8E1943222D006BCE48 /* ExSwiftTests */,
+				1E11AF831943222D006BCE48 /* ExSwift-OSX */,
+				1E11AF8E1943222D006BCE48 /* ExSwiftTests-OSX */,
+				24D9BBE51AC54B30000FDBB8 /* ExSwift-iOS */,
+				24D9BBEF1AC54B31000FDBB8 /* ExSwiftTests-iOS */,
 			);
 		};
 /* End PBXProject section */
@@ -265,6 +384,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		1E11AF8D1943222D006BCE48 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		24D9BBE41AC54B30000FDBB8 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		24D9BBEE1AC54B31000FDBB8 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -324,7 +457,65 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		24D9BBE11AC54B30000FDBB8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24D9BC001AC54C1C000FDBB8 /* Sequence.swift in Sources */,
+				24D9BC011AC54C1C000FDBB8 /* ExSwift.swift in Sources */,
+				24D9BC021AC54C1C000FDBB8 /* Array.swift in Sources */,
+				24D9BC031AC54C1C000FDBB8 /* Character.swift in Sources */,
+				24D9BC041AC54C1C000FDBB8 /* Dictionary.swift in Sources */,
+				24D9BC051AC54C1C000FDBB8 /* Double.swift in Sources */,
+				24D9BC061AC54C1C000FDBB8 /* Float.swift in Sources */,
+				24D9BC071AC54C1C000FDBB8 /* Int.swift in Sources */,
+				24D9BC081AC54C1C000FDBB8 /* Range.swift in Sources */,
+				24D9BC091AC54C1C000FDBB8 /* String.swift in Sources */,
+				24D9BC0A1AC54C1C000FDBB8 /* NSArray.swift in Sources */,
+				24D9BC0B1AC54C1C000FDBB8 /* NSDate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		24D9BBEC1AC54B31000FDBB8 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				24D9BC181AC54C32000FDBB8 /* ExSwiftSequenceTests.swift in Sources */,
+				24D9BC191AC54C32000FDBB8 /* ExSwiftArrayTests.swift in Sources */,
+				24D9BC1A1AC54C32000FDBB8 /* ExSwiftCharacterTests.swift in Sources */,
+				24D9BC1B1AC54C32000FDBB8 /* ExSwiftDictionaryTests.swift in Sources */,
+				24D9BC1C1AC54C32000FDBB8 /* ExSwiftDoubleTests.swift in Sources */,
+				24D9BC1D1AC54C32000FDBB8 /* ExSwiftFloatTests.swift in Sources */,
+				24D9BC1E1AC54C32000FDBB8 /* ExSwiftIntTests.swift in Sources */,
+				24D9BC1F1AC54C32000FDBB8 /* ExSwiftRangeTests.swift in Sources */,
+				24D9BC201AC54C32000FDBB8 /* ExSwiftStringTests.swift in Sources */,
+				24D9BC211AC54C32000FDBB8 /* ExSwiftTests.swift in Sources */,
+				24D9BC221AC54C32000FDBB8 /* ExSwiftNSArrayTests.swift in Sources */,
+				24D9BC231AC54C32000FDBB8 /* ExSwiftNSDateTests.swift in Sources */,
+				24D9BC0C1AC54C2B000FDBB8 /* Sequence.swift in Sources */,
+				24D9BC0D1AC54C2B000FDBB8 /* ExSwift.swift in Sources */,
+				24D9BC0E1AC54C2B000FDBB8 /* Array.swift in Sources */,
+				24D9BC0F1AC54C2B000FDBB8 /* Character.swift in Sources */,
+				24D9BC101AC54C2B000FDBB8 /* Dictionary.swift in Sources */,
+				24D9BC111AC54C2B000FDBB8 /* Double.swift in Sources */,
+				24D9BC121AC54C2B000FDBB8 /* Float.swift in Sources */,
+				24D9BC131AC54C2B000FDBB8 /* Int.swift in Sources */,
+				24D9BC141AC54C2B000FDBB8 /* Range.swift in Sources */,
+				24D9BC151AC54C2B000FDBB8 /* String.swift in Sources */,
+				24D9BC161AC54C2B000FDBB8 /* NSArray.swift in Sources */,
+				24D9BC171AC54C2B000FDBB8 /* NSDate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		24D9BBF31AC54B31000FDBB8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 24D9BBE51AC54B30000FDBB8 /* ExSwift-iOS */;
+			targetProxy = 24D9BBF21AC54B31000FDBB8 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		1E11AF981943222D006BCE48 /* Debug */ = {
@@ -428,7 +619,8 @@
 				INFOPLIST_FILE = ExSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_NAME = ExSwift;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
 			};
@@ -447,7 +639,8 @@
 				INFOPLIST_FILE = ExSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				PRODUCT_NAME = ExSwift;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -467,7 +660,7 @@
 				INFOPLIST_FILE = ExSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = ExSwiftTests;
 			};
 			name = Debug;
 		};
@@ -482,7 +675,97 @@
 				INFOPLIST_FILE = ExSwiftTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks @executable_path/Frameworks @loader_path/Frameworks";
 				METAL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = ExSwiftTests;
+			};
+			name = Release;
+		};
+		24D9BBFA1AC54B31000FDBB8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = ExSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = ExSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		24D9BBFB1AC54B31000FDBB8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = ExSwift/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = ExSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		24D9BBFD1AC54B31000FDBB8 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = ExSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				PRODUCT_NAME = ExSwiftTests;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		24D9BBFE1AC54B31000FDBB8 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+				);
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = ExSwiftTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_NAME = ExSwiftTests;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
 		};
@@ -498,7 +781,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1E11AF9A1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwift" */ = {
+		1E11AF9A1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwift-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1E11AF9B1943222D006BCE48 /* Debug */,
@@ -507,11 +790,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		1E11AF9D1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwiftTests" */ = {
+		1E11AF9D1943222D006BCE48 /* Build configuration list for PBXNativeTarget "ExSwiftTests-OSX" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				1E11AF9E1943222D006BCE48 /* Debug */,
 				1E11AF9F1943222D006BCE48 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		24D9BBF91AC54B31000FDBB8 /* Build configuration list for PBXNativeTarget "ExSwift-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				24D9BBFA1AC54B31000FDBB8 /* Debug */,
+				24D9BBFB1AC54B31000FDBB8 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		24D9BBFC1AC54B31000FDBB8 /* Build configuration list for PBXNativeTarget "ExSwiftTests-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				24D9BBFD1AC54B31000FDBB8 /* Debug */,
+				24D9BBFE1AC54B31000FDBB8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ExSwift.xcodeproj/xcshareddata/xcschemes/ExSwift-OSX.xcscheme
+++ b/ExSwift.xcodeproj/xcshareddata/xcschemes/ExSwift-OSX.xcscheme
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0610"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1E11AF831943222D006BCE48"
+               BuildableName = "ExSwift.framework"
+               BlueprintName = "ExSwift-OSX"
+               ReferencedContainer = "container:ExSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1E11AF8E1943222D006BCE48"
+               BuildableName = "ExSwiftTests.xctest"
+               BlueprintName = "ExSwiftTests-OSX"
+               ReferencedContainer = "container:ExSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      buildConfiguration = "Debug">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1E11AF8E1943222D006BCE48"
+               BuildableName = "ExSwiftTests.xctest"
+               BlueprintName = "ExSwiftTests-OSX"
+               ReferencedContainer = "container:ExSwift.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1E11AF831943222D006BCE48"
+            BuildableName = "ExSwift.framework"
+            BlueprintName = "ExSwift-OSX"
+            ReferencedContainer = "container:ExSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </TestAction>
+   <LaunchAction
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1E11AF831943222D006BCE48"
+            BuildableName = "ExSwift.framework"
+            BlueprintName = "ExSwift-OSX"
+            ReferencedContainer = "container:ExSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Release"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1E11AF831943222D006BCE48"
+            BuildableName = "ExSwift.framework"
+            BlueprintName = "ExSwift-OSX"
+            ReferencedContainer = "container:ExSwift.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ExSwift.xcodeproj/xcshareddata/xcschemes/ExSwift-iOS.xcscheme
+++ b/ExSwift.xcodeproj/xcshareddata/xcschemes/ExSwift-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0630"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,23 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1E11AF831943222D006BCE48"
+               BlueprintIdentifier = "24D9BBE51AC54B30000FDBB8"
                BuildableName = "ExSwift.framework"
-               BlueprintName = "ExSwift"
+               BlueprintName = "ExSwift-iOS"
+               ReferencedContainer = "container:ExSwift.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "24D9BBEF1AC54B31000FDBB8"
+               BuildableName = "ExSwiftTests.xctest"
+               BlueprintName = "ExSwiftTests-iOS"
                ReferencedContainer = "container:ExSwift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -32,9 +46,9 @@
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "1E11AF8E1943222D006BCE48"
+               BlueprintIdentifier = "24D9BBEF1AC54B31000FDBB8"
                BuildableName = "ExSwiftTests.xctest"
-               BlueprintName = "ExSwiftTests"
+               BlueprintName = "ExSwiftTests-iOS"
                ReferencedContainer = "container:ExSwift.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -42,9 +56,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1E11AF831943222D006BCE48"
+            BlueprintIdentifier = "24D9BBE51AC54B30000FDBB8"
             BuildableName = "ExSwift.framework"
-            BlueprintName = "ExSwift"
+            BlueprintName = "ExSwift-iOS"
             ReferencedContainer = "container:ExSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -61,9 +75,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1E11AF831943222D006BCE48"
+            BlueprintIdentifier = "24D9BBE51AC54B30000FDBB8"
             BuildableName = "ExSwift.framework"
-            BlueprintName = "ExSwift"
+            BlueprintName = "ExSwift-iOS"
             ReferencedContainer = "container:ExSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -79,9 +93,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "1E11AF831943222D006BCE48"
+            BlueprintIdentifier = "24D9BBE51AC54B30000FDBB8"
             BuildableName = "ExSwift.framework"
-            BlueprintName = "ExSwift"
+            BlueprintName = "ExSwift-iOS"
             ReferencedContainer = "container:ExSwift.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # ExSwift
+![CocoaPods](https://img.shields.io/cocoapods/v/ExSwift.svg) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 Set of Swift extensions for standard types and classes.
 
 # Installation
 
 Because of Xcode errors it's not possible to integrate this project with Cocoapods or as Embedded Framework.
-[Read more at Dev Forum](https://devforums.apple.com/message/983747#983747)  
+[Read more at Dev Forum](https://devforums.apple.com/message/983747#983747)
 
 ## Use submodule and copy source code
 1. Add ExSwift as a submodule


### PR DESCRIPTION
In a previous change, basic Carthage support was added to the project. This made the project accessible for Carthage users but only if they were building for OSX; there were no targets, and no schemes, for iOS.
This change renames the existing OSX targets to ExSwift-OSX and adds ExSwift-iOS targets to the project.  These targets are for building a CocoaTouch Framework and the associated tests.  A second shared scheme, called ExSwift-iOS (the original was renamed ExSwift-OSX) was created as well.  This will allow Carthage to build for either platform.  Finally both a CocoaPods and Carthage badge were added to the `README` file.