### PR TITLE
Travis CI Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: objective-c
+xcode_project: ExSwift.xcodeproj
+xcode_scheme:
+- ExSwift-iOS
+- ExSwift-OSX
+xcode_sdk:
+- iphonesimulator7
+- iphonesimulator8.1
+- macosx10.10
+- macosx10.9
+
+matrix:
+  exclude:
+  - xcode_scheme: ExSwift-iOS
+    xcode_sdk: macosx10.9
+  - xcode_scheme: ExSwift-iOS
+    xcode_sdk: macosx10.10
+  - xcode_scheme: ExSwift-OSX
+    xcode_sdk: iphonesimulator7
+  - xcode_scheme: ExSwift-OSX
+    xcode_sdk: iphonesimulator8.1

--- a/ExSwift.xcodeproj/project.pbxproj
+++ b/ExSwift.xcodeproj/project.pbxproj
@@ -619,7 +619,7 @@
 				INFOPLIST_FILE = ExSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = ExSwift;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
@@ -639,7 +639,7 @@
 				INFOPLIST_FILE = ExSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				MACOSX_DEPLOYMENT_TARGET = 10.9;
 				PRODUCT_NAME = ExSwift;
 				SKIP_INSTALL = YES;
 			};
@@ -694,7 +694,7 @@
 				);
 				INFOPLIST_FILE = ExSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
 				PRODUCT_NAME = ExSwift;
@@ -716,7 +716,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				INFOPLIST_FILE = ExSwift/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.1;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
 				PRODUCT_NAME = ExSwift;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ExSwift
-![CocoaPods](https://img.shields.io/cocoapods/v/ExSwift.svg) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
+![CocoaPods](https://img.shields.io/cocoapods/v/ExSwift.svg) [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage) [![Build Status](https://travis-ci.org/pNre/ExSwift.svg)](https://travis-ci.org/pNre/ExSwift)
 
 Set of Swift extensions for standard types and classes.
 


### PR DESCRIPTION
This change adds Travis CI support to the project.  It adds build configuration for both the iOS and OSX schemes.  The `README` is also update with a build status badge.