### PR TITLE
Fix hour and day  order in iOS7 version of NSDate add

### DIFF
--- a/ExSwift/NSDate.swift
+++ b/ExSwift/NSDate.swift
@@ -24,27 +24,34 @@ public extension NSDate {
         :param: years number of years to add
         :returns: the NSDate computed
     */
-    public func add(seconds: Int = 0, minutes: Int = 0, hours: Int = 0, days: Int = 0, weeks: Int = 0, months: Int = 0, years: Int = 0) -> NSDate {
+   public func add(seconds: Int = 0, minutes: Int = 0, hours: Int = 0, days: Int = 0, weeks: Int = 0, months: Int = 0, years: Int = 0) -> NSDate {
         var calendar = NSCalendar.currentCalendar()
         let version = floor(NSFoundationVersionNumber)
         if ( version <= NSFoundationVersionNumber_iOS_7_1 || version <= NSFoundationVersionNumber10_9_2  ) {
             var component = NSDateComponents()
             component.setValue(seconds, forComponent: .CalendarUnitSecond)
+            
             var date : NSDate! = calendar.dateByAddingComponents(component, toDate: self, options: nil)!
             component = NSDateComponents()
             component.setValue(minutes, forComponent: .CalendarUnitMinute)
             date = calendar.dateByAddingComponents(component, toDate: date, options: nil)!
-            component = NSDateComponents()
-            component.setValue(days, forComponent: .CalendarUnitDay)
-            date = calendar.dateByAddingComponents(component, toDate: date, options: nil)!
+            
             component = NSDateComponents()
             component.setValue(hours, forComponent: .CalendarUnitHour)
             date = calendar.dateByAddingComponents(component, toDate: date, options: nil)!
+            
+            component = NSDateComponents()
+            component.setValue(days, forComponent: .CalendarUnitDay)
+            date = calendar.dateByAddingComponents(component, toDate: date, options: nil)!
+            
+            component = NSDateComponents()
             component.setValue(weeks, forComponent: .CalendarUnitWeekOfMonth)
             date = calendar.dateByAddingComponents(component, toDate: date, options: nil)!
+            
             component = NSDateComponents()
             component.setValue(months, forComponent: .CalendarUnitMonth)
             date = calendar.dateByAddingComponents(component, toDate: date, options: nil)!
+            
             component = NSDateComponents()
             component.setValue(years, forComponent: .CalendarUnitYear)
             date = calendar.dateByAddingComponents(component, toDate: date, options: nil)!


### PR DESCRIPTION
Hour and day was in the wrong order and in some case produce wrong results on iOS 7