### PR TITLE
Fixes Array.get() implicit wrapping with negative index values

### DIFF
--- a/ExSwift/Array.swift
+++ b/ExSwift/Array.swift
@@ -207,19 +207,7 @@ internal extension Array {
     */
     func get (index: Int) -> Element? {
 
-        //  If the index is out of bounds it's assumed relative
-        func relativeIndex (index: Int) -> Int {
-            var _index = (index % count)
-
-            if _index < 0 {
-                _index = count + _index
-            }
-
-            return _index
-        }
-
-        let _index = relativeIndex(index)
-        return _index < count ? self[_index] : nil
+        return (index < count && index >= 0) ? self[index] : nil
     }
 
     /**

--- a/ExSwift/String.swift
+++ b/ExSwift/String.swift
@@ -57,7 +57,8 @@ public extension String {
         :returns: Character as String or nil if the index is out of bounds
     */
     subscript (index: Int) -> String? {
-        if let char = Array(self).get(index) {
+        var _index = index < 0 ? self.length + index : index
+        if let char = Array(self).get(_index) {
             return String(char)
         }
 

--- a/ExSwiftTests/ExSwiftArrayTests.swift
+++ b/ExSwiftTests/ExSwiftArrayTests.swift
@@ -377,8 +377,8 @@ class ExtensionsArrayTests: XCTestCase {
     
     func testGet () {
         XCTAssertEqual(1, array.get(0)!)
-        XCTAssertEqual(array.get(-1)!, array.last!)
-        XCTAssertEqual(array.get(array.count)!, array.first!)
+        XCTAssertNil(array.get(-1))
+        XCTAssertNil(array.get(array.count))
     }
 
     func testDuplicationOperator () {


### PR DESCRIPTION
This is a response to #100.