### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Set of Swift extensions for standard types and classes.
 
 # Installation
 
-Because of Xcode errors it's not possible to integrate this project with Cocoapods or as Embedded Framework.
+Because of Xcode errors it's not possible to integrate this project with CocoaPods or as Embedded Framework.
 [Read more at Dev Forum](https://devforums.apple.com/message/983747#983747)
 
 ## Use submodule and copy source code


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
